### PR TITLE
Add real eBPF XDP fallback for memory reading

### DIFF
--- a/capabilities.c
+++ b/capabilities.c
@@ -12,9 +12,10 @@
  * 
  *  Capabilities needed in some cases
  *  
- *  CAP_SYS_ADMIN   ->  needed to change /proc/sys/kernel/kptr_restrict from 2 to 0 (not needed if set to 1 or 0), needed to access
+ *  CAP_SYS_ADMIN    -> needed to change /proc/sys/kernel/kptr_restrict from 2 to 0 (not needed if set to 1 or 0), needed to access
  *                      /proc/iomem if CONFIG_KALLSYMS_ALL is not active and so iomem_resources is not available, needed on old kernels
  *  CAP_DAC_OVERRIDE -> needed to create a brand new dump file in the case the directory is not owned by the user running LEMON
+ *  CAP_NET_RAW      -> needed to create raw sockets for XDP
  */
 
 

--- a/capabilities.c
+++ b/capabilities.c
@@ -15,7 +15,6 @@
  *  CAP_SYS_ADMIN    -> needed to change /proc/sys/kernel/kptr_restrict from 2 to 0 (not needed if set to 1 or 0), needed to access
  *                      /proc/iomem if CONFIG_KALLSYMS_ALL is not active and so iomem_resources is not available, needed on old kernels
  *  CAP_DAC_OVERRIDE -> needed to create a brand new dump file in the case the directory is not owned by the user running LEMON
- *  CAP_NET_RAW      -> needed to create raw sockets for XDP
  */
 
 

--- a/cpu_stealer.c
+++ b/cpu_stealer.c
@@ -29,7 +29,7 @@ typedef struct {
  * @param priority: The priority to set for the current process.
  * @return 0 on success, -1 on failure.
  */
-static int set_priority(const int priority){
+static int set_priority(const int priority) {
     const struct sched_param sparam = {
         .sched_priority = priority
     };

--- a/dump.c
+++ b/dump.c
@@ -30,8 +30,7 @@ static int dump_region(const uintptr_t region_start, const uintptr_t region_end,
     unsigned char *read_data = NULL;
 
     chunk_start = region_start;
-    while (chunk_start <= region_end)
-    {
+    while (chunk_start <= region_end) {
         /* Read memory region in chunks of maximum granule bytes */
         chunk_end = (region_end - chunk_start + 1 > granule) ? chunk_start + granule - 1 : region_end;
         chunk_size = chunk_end - chunk_start + 1;

--- a/lemon.c
+++ b/lemon.c
@@ -119,8 +119,7 @@ static int check_kernel_version() {
     return (major > MIN_MAJOR_LINUX) || ((major == MIN_MAJOR_LINUX) && (minor >= MIN_MINOR_LINUX));
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     struct ram_regions ram_regions;
     struct options opts = {0};
     struct argp argp = {options, parse_opt, "", doc};

--- a/lemon.h
+++ b/lemon.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <errno.h>
 
-#define MIN_MAJOR_LINUX         5 /* Minimium kernel version supported */
+#define MIN_MAJOR_LINUX         5                       /* Minimium kernel version supported */
 #define MIN_MINOR_LINUX         5
 
 #define HUGE_PAGE_SIZE          2 * 1024 * 1024         /* Same for huge pages */

--- a/mem.c
+++ b/mem.c
@@ -218,7 +218,8 @@ int load_ebpf_mem_progs() {
         /* Attach XDP program to the interface */
         bpf_prog_link = bpf_program__attach_xdp(mem_ebpf_skel->progs.read_kernel_memory_xdp, ifindex);
         if (!bpf_prog_link) {
-            fprintf(stderr, "Failed to attach XDP program to interface %s (index: %d)\n", loopback_interface, ifindex);
+            fprintf(stderr, "Failed to attach XDP program to interface %s...\n", loopback_interface);
+            return -errno;
         }
         
         /* Create socket for sending trigger packets */

--- a/net.c
+++ b/net.c
@@ -20,7 +20,6 @@ struct net_args {
  *
  * Returns 0 on success.
  */
-
 int write_on_socket(void *restrict args, const void *restrict data, const unsigned long size) {
     unsigned long r;
     unsigned long total;
@@ -48,7 +47,6 @@ int write_on_socket(void *restrict args, const void *restrict data, const unsign
  *
  * On success, it returns 0. On failure, a negative value or errno is returned.
  */
-
 int dump_on_net(const struct options *restrict opts, const struct ram_regions *restrict ram_regions) {
     int sockfd;
     struct sockaddr_in dest_addr;
@@ -86,5 +84,3 @@ int dump_on_net(const struct options *restrict opts, const struct ram_regions *r
     
     return ret;
 }
-
-    


### PR DESCRIPTION
- refactor eBPF XDP program to parse UDP packets
- use UDP instead of raw socket and bpf_prog_test_run_opts() for XDP triggers